### PR TITLE
Add extra data for course and activity id this room is in

### DIFF
--- a/classes/external/mod_plugnmeet_create_room.php
+++ b/classes/external/mod_plugnmeet_create_room.php
@@ -90,7 +90,11 @@ class mod_plugnmeet_create_room extends external_api {
             $extradata = json_encode(array(
                 "platform" => "moodle",
                 "php-version" => phpversion(),
-                "plugin-version" => $config->version
+                "plugin-version" => $config->version,
+                "activity" => array(
+                    "id" => $cm->id,
+                    "course" => $cm->course,
+                )
             ));
             $res = $connect->createRoom($instance->roomid,
                 $instance->name,


### PR DESCRIPTION
This PR adds some extra data that is required for opencast and moodle integration. This is needed, because each moodle course has its own opencast series for example Course_Series_2 where 2 is the course id, to tie together plugnmeet recordings and opencast series I would need these extra parameters.